### PR TITLE
add --format csv support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
 cache:
   directories:
     - node_modules
+env:
+  - BBY_API_KEY=XXX

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Usage: bestbuy [resource] [options]
     --show, -s            fields to show
     --sort, -r            sort results by fields (comma separated)
     --key, -k             Best Buy API key (default: "BBY_API_KEY environment variable")
-    --format, -f          format of the response as json, xml, or csv (default: "json")
+    --format, -f          format of the response as json, xml, csv, or tsv (default: "json")
     --output, -o          name of file to send output (optional; If not present, out will go to stdout)
     --bare, -b            newline delimited - each item on own line without extra cruft (default: false)
     --version, -v         show version information

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Usage: bestbuy [resource] [options]
     --show, -s            fields to show
     --sort, -r            sort results by fields (comma separated)
     --key, -k             Best Buy API key (default: "BBY_API_KEY environment variable")
-    --format, -f          format of the response as json or xml (default: "json")
+    --format, -f          format of the response as json, xml, or csv (default: "json")
     --output, -o          name of file to send output (optional; If not present, out will go to stdout)
     --bare, -b            newline delimited - each item on own line without extra cruft (default: false)
     --version, -v         show version information

--- a/bin.js
+++ b/bin.js
@@ -30,7 +30,7 @@ function cli (args, stream, cb) {
     {
       name: 'format',
       abbr: 'f',
-      help: 'format of the response as json or xml',
+      help: 'format of the response as json, xml, or csv',
       default: 'json'
     },
     {

--- a/bin.js
+++ b/bin.js
@@ -30,7 +30,7 @@ function cli (args, stream, cb) {
     {
       name: 'format',
       abbr: 'f',
-      help: 'format of the response as json, xml, or csv',
+      help: 'format of the response as json, xml, csv or tsv',
       default: 'json'
     },
     {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function run (opts, stdout, cb) {
   opts.format = opts.format.toLowerCase()
 
   var dataStream = bby[`${opts.resource}AsStream`](opts.query, {
-    format: opts.format === 'csv' ? 'json' : opts.format,
+    format: opts.format === 'csv' || opts.format === 'tsv' ? 'json' : opts.format,
     show: opts.show,
     sort: opts.sort
   })
@@ -37,10 +37,11 @@ function run (opts, stdout, cb) {
 
   if (opts.format === 'json') {
     parser = opts.bare ? JSONStream.stringify(false) : JSONStream.stringify()
-  } else if (opts.format === 'csv') {
+  } else if (opts.format === 'csv' || opts.format === 'tsv') {
     var csvStream = csv.createWriteStream({
       headers: !opts.bare,
-      objectMode: false
+      objectMode: false,
+      delimiter: opts.format === 'tsv' ? '\t' : ','
     })
     parser = csvStream
   } else if (opts.format === 'xml') {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const JSONStream = require('JSONStream')
 const logUpdate = require('log-update')
 const prettyMs = require('pretty-ms')
 const through = require('through2')
+const csv = require('fast-csv')
 
 function run (opts, stdout, cb) {
   var bby = bestbuy({key: opts.key})
@@ -19,8 +20,10 @@ function run (opts, stdout, cb) {
   var output
   var parser
 
+  opts.format = opts.format.toLowerCase()
+
   var dataStream = bby[`${opts.resource}AsStream`](opts.query, {
-    format: opts.format,
+    format: opts.format === 'csv' ? 'json' : opts.format,
     show: opts.show,
     sort: opts.sort
   })
@@ -32,9 +35,15 @@ function run (opts, stdout, cb) {
 
   dataStream.on('data', () => cnt++)
 
-  if (opts.format.toLowerCase() === 'json') {
+  if (opts.format === 'json') {
     parser = opts.bare ? JSONStream.stringify(false) : JSONStream.stringify()
-  } else if (opts.format.toLowerCase() === 'xml') {
+  } else if (opts.format === 'csv') {
+    var csvStream = csv.createWriteStream({
+      headers: !opts.bare,
+      objectMode: false
+    })
+    parser = csvStream
+  } else if (opts.format === 'xml') {
     parser = through(
       function (chunk, enc, cb) {
         if (opts.bare) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "JSONStream": "^1.3.1",
     "bestbuy": "^2.0.1",
     "cliclopts": "^1.1.1",
+    "fast-csv": "^2.4.0",
     "log-update": "^2.1.0",
     "minimist": "^1.2.0",
     "pretty-ms": "^3.0.0",

--- a/test/fixtures/fetch products as csv without the header row using --bare_.json
+++ b/test/fixtures/fetch products as csv without the header row using --bare_.json
@@ -1,0 +1,86 @@
+[
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=*&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.007",
+            "totalTime": "0.012",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=*&format=json&apiKey=XXX",
+            "products": [
+                {
+                    "name": "Super Mario Odyssey - Nintendo Switch",
+                    "salePrice": 59.99,
+                    "url": "https://api.bestbuy.com/click/-/5721722/pdp"
+                }
+            ]
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:29:39 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "407",
+            "Connection",
+            "Close"
+        ]
+    },
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM%3D&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.009",
+            "totalTime": "0.009",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=&format=json&apiKey=XXX",
+            "products": []
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:29:39 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "324",
+            "Connection",
+            "Close"
+        ]
+    }
+]

--- a/test/fixtures/fetch products as csv_.json
+++ b/test/fixtures/fetch products as csv_.json
@@ -1,0 +1,86 @@
+[
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=*&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.007",
+            "totalTime": "0.012",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=*&format=json&apiKey=XXX",
+            "products": [
+                {
+                    "name": "Super Mario Odyssey - Nintendo Switch",
+                    "salePrice": 59.99,
+                    "url": "https://api.bestbuy.com/click/-/5721722/pdp"
+                }
+            ]
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:34:34 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "407",
+            "Connection",
+            "Close"
+        ]
+    },
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM%3D&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.009",
+            "totalTime": "0.009",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=&format=json&apiKey=XXX",
+            "products": []
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:32:55 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "324",
+            "Connection",
+            "Close"
+        ]
+    }
+]

--- a/test/fixtures/fetch products as tsv without the header row using --bare_.json
+++ b/test/fixtures/fetch products as tsv without the header row using --bare_.json
@@ -1,0 +1,86 @@
+[
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=*&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.007",
+            "totalTime": "0.012",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=*&format=json&apiKey=XXX",
+            "products": [
+                {
+                    "name": "Super Mario Odyssey - Nintendo Switch",
+                    "salePrice": 59.99,
+                    "url": "https://api.bestbuy.com/click/-/5721722/pdp"
+                }
+            ]
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:59:30 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "407",
+            "Connection",
+            "Close"
+        ]
+    },
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM%3D&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.009",
+            "totalTime": "0.009",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=&format=json&apiKey=XXX",
+            "products": []
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:59:30 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "324",
+            "Connection",
+            "Close"
+        ]
+    }
+]

--- a/test/fixtures/fetch products as tsv_.json
+++ b/test/fixtures/fetch products as tsv_.json
@@ -1,0 +1,86 @@
+[
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=*&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.007",
+            "totalTime": "0.012",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=*&format=json&apiKey=XXX",
+            "products": [
+                {
+                    "name": "Super Mario Odyssey - Nintendo Switch",
+                    "salePrice": 59.99,
+                    "url": "https://api.bestbuy.com/click/-/5721722/pdp"
+                }
+            ]
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:56:13 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "407",
+            "Connection",
+            "Close"
+        ]
+    },
+    {
+        "scope": "https://api.bestbuy.com:443",
+        "method": "get",
+        "path": "/v1/products(sku=5721722)?format=json&apiKey=XXX&show=name,salePrice,url&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM%3D&pageSize=100",
+        "body": "",
+        "status": 200,
+        "response": {
+            "nextCursorMark": "AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=",
+            "total": 1,
+            "totalPages": 1,
+            "queryTime": "0.009",
+            "totalTime": "0.009",
+            "partial": false,
+            "canonicalUrl": "/v1/products(sku=5721722)?show=name,salePrice,url&pageSize=100&cursorMark=AoIIP4AAADJwcm9kdWN0XzU3MjE3MjJfdXM=&format=json&apiKey=XXX",
+            "products": []
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Headers",
+            "origin, x-requested-with, accept",
+            "Access-Control-Allow-Methods",
+            "GET",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Access-Control-Max-Age",
+            "3628800",
+            "Content-Type",
+            "application/json; charset=UTF-8",
+            "Date",
+            "Mon, 25 Sep 2017 17:56:13 GMT",
+            "Server",
+            "Best Buy Public APIs",
+            "X-Cache-Hit",
+            "true",
+            "Content-Length",
+            "324",
+            "Connection",
+            "Close"
+        ]
+    }
+]

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -186,3 +186,22 @@ test('fetch all stores and sort by name desc', function (t) {
     t.end()
   })
 })
+
+test('fetch products as csv', function (t) {
+  bestbuy('products -q "sku=5721722" -s "name,salePrice,url" -f csv', function (err, output) {
+    t.error(err, 'no error')
+
+    var expected = `name,salePrice,url\nSuper Mario Odyssey - Nintendo Switch,59.99,https://api.bestbuy.com/click/-/5721722/pdp`
+    t.equals(output, expected, 'csv header row present')
+    t.end()
+  })
+})
+
+test('fetch products as csv without the header row using --bare', function (t) {
+  bestbuy('products --query "sku=5721722" --show "name,salePrice,url" --format csv --bare', function (err, output) {
+    t.error(err, 'no error')
+    var expected = `Super Mario Odyssey - Nintendo Switch,59.99,https://api.bestbuy.com/click/-/5721722/pdp`
+    t.equals(output, expected, 'csv header row not present')
+    t.end()
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -205,3 +205,22 @@ test('fetch products as csv without the header row using --bare', function (t) {
     t.end()
   })
 })
+
+test('fetch products as tsv', function (t) {
+  bestbuy('products -q "sku=5721722" -s "name,salePrice,url" -f tsv', function (err, output) {
+    t.error(err, 'no error')
+
+    var expected = `name\tsalePrice\turl\nSuper Mario Odyssey - Nintendo Switch\t59.99\thttps://api.bestbuy.com/click/-/5721722/pdp`
+    t.equals(output, expected, 'tsv header row present')
+    t.end()
+  })
+})
+
+test('fetch products as tsv without the header row using --bare', function (t) {
+  bestbuy('products --query "sku=5721722" --show "name,salePrice,url" --format tsv --bare', function (err, output) {
+    t.error(err, 'no error')
+    var expected = `Super Mario Odyssey - Nintendo Switch\t59.99\thttps://api.bestbuy.com/click/-/5721722/pdp`
+    t.equals(output, expected, 'csv header row not present')
+    t.end()
+  })
+})


### PR DESCRIPTION
- Since the Best Buy API does not support cursorMarks when format=csv, we're fetching data as JSON and converting it to CSV on the fly.
- The `--bare` flag will turn off the CSV header row.